### PR TITLE
support db-api 2.0

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,14 @@
+[run]
+branch = True
+source=pydataapi
+
+[report]
+exclude_lines =
+    if self.debug:
+    pragma: no cover
+    raise NotImplementedError
+    if __name__ == .__main__.:
+    pass
+ignore_errors = True
+omit =
+    tests/*

--- a/README.md
+++ b/README.md
@@ -5,6 +5,12 @@
 [![codecov](https://codecov.io/gh/koxudaxi/py-data-api/branch/master/graph/badge.svg)](https://codecov.io/gh/koxudaxi/py-data-api)
 
 py-data-api is a user-friendly client which supports SQLAlchemy models.
+Also, the package includes DB API 2.0 Client and SQLAlchemy Dialects.
+
+## Features
+- A user-friendly client which supports SQLAlchemy models
+- SQLAlchemy Dialects (experimental)
+- DB API 2.0 compatible client [PEP 249](https://www.python.org/dev/peps/pep-0249/)
 
 ## What's AWS Aurora Serverless's Data API?
 https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/data-api.html
@@ -149,25 +155,24 @@ def example_rollback_with_custom_exception():
         raise OriginalError  # rollback
 
         # raise Exception <- DataAPI don't rollback
+
+def example_driver_for_sqlalchemy():
+    from sqlalchemy.engine import create_engine
+    engine = create_engine(
+        'mysql+pydataapi://',
+        connect_args={
+            'resource_arn': 'arn:aws:rds:us-east-1:123456789012:cluster:dummy',
+            'secret_arn': 'arn:aws:secretsmanager:us-east-1:123456789012:secret:dummy',
+            'database': 'test'}
+    )
+
+    result: ResultProxy = engine.execute("select * from pets")
+    print(result.fetchall())
+
 ```
-
-## 
-## Features
-### Implemented
-- `BeginTransaction`  - core  
-- `CommitTransaction` - core 
-- `ExecuteStatement` - core 
-- `RollbackTransaction` - core
-- `BatchExecuteStatement` - core
-
-### Not Implemented
-
-- `ExecuteSql(Deprecated API)`
-
 
 ## TODO
 - add documents include docstrings
-- add simply function client
 
 ## Related projects
 ### local-data-api

--- a/example.py
+++ b/example.py
@@ -130,21 +130,13 @@ def example_rollback_with_custom_exception():
 
 def example_driver_for_sqlalchemy():
     from sqlalchemy.engine import create_engine
-    import boto3
-    client = boto3.client('rds-data', endpoint_url='http://127.0.0.1:8080', aws_access_key_id='aaa',
-                          aws_secret_access_key='bbb')
     engine = create_engine(
         'mysql+pydataapi://',
-        echo=True,
         connect_args={
             'resource_arn': 'arn:aws:rds:us-east-1:123456789012:cluster:dummy',
             'secret_arn': 'arn:aws:secretsmanager:us-east-1:123456789012:secret:dummy',
-            'database': 'test',
-            'client': client}
+            'database': 'test'}
     )
 
     result: ResultProxy = engine.execute("select * from pets")
     print(result.fetchall())
-
-
-example_driver_for_sqlalchemy()

--- a/pydataapi/__init__.py
+++ b/pydataapi/__init__.py
@@ -1,3 +1,17 @@
+from . import dialect
+from .dbapi import Connection, Cursor, apilevel, connect, paramstyle, threadsafety
 from .pydataapi import DataAPI, Record, Result, transaction
 
-__all__ = ['DataAPI', 'transaction', 'Result', 'Record']
+__all__ = [
+    'DataAPI',
+    'transaction',
+    'Result',
+    'Record',
+    'Connection',
+    'connect',
+    'Cursor',
+    'apilevel',
+    'threadsafety',
+    'paramstyle',
+    'dialect',
+]

--- a/pydataapi/dbapi.py
+++ b/pydataapi/dbapi.py
@@ -1,0 +1,185 @@
+from typing import Any, Callable, Dict, Iterator, List, Optional, Sequence, Tuple, Type
+
+import boto3
+from pydantic import BaseModel
+
+from .pydataapi import DataAPI
+
+apilevel: str = '2.0'
+threadsafety: int = 2
+paramstyle: str = 'named'
+
+
+def get_description(column_metadata: List[Dict[str, Any]]) -> Tuple:
+    return tuple(
+        (
+            meta['label'],  # name
+            0,  # type_code,
+            0,  # display_size,
+            0,  # internal_size,
+            meta['precision'],  # precision,
+            meta['scale'],  # scale,
+            meta['nullable'],
+        )
+        for meta in column_metadata
+    )
+
+
+class Error(Exception):
+    pass
+
+
+class ConnectArgs(BaseModel):
+    resource_arn: str
+    secret_arn: str
+    database: Optional[str] = None
+    transaction_id: Optional[str] = None
+    client: Optional[Any] = None
+    rollback_exception: Optional[Type[Exception]] = None
+
+
+class Connection:
+    paramstyle = paramstyle
+    Error = Error
+
+    def __init__(self, **kwargs: Any) -> None:
+        connect_args = ConnectArgs.parse_obj(kwargs)
+        self._data_api = DataAPI(
+            connect_args.resource_arn,
+            connect_args.secret_arn,
+            connect_args.database,
+            connect_args.transaction_id,
+            connect_args.client,
+            connect_args.rollback_exception,
+        )
+
+        self.closed = False
+        self.cursors: List[Cursor] = []
+
+    def close(self) -> None:
+        self.closed = True
+
+    def commit(self) -> None:
+        if self._data_api.transaction_id:
+            self._data_api.commit()
+
+    def rollback(self) -> None:
+        if self._data_api.transaction_id:
+            self._data_api.rollback()
+
+    def cursor(self) -> 'Cursor':
+        cursor = Cursor(self._data_api)
+        self.cursors.append(cursor)
+
+        return cursor
+
+    @classmethod
+    def connect(cls, **kwargs: Any) -> 'Connection':
+        return cls(**kwargs)
+
+    def execute(self, operation: Any, parameters: Any = None) -> 'Cursor':
+        return self.cursor().execute(operation, parameters)
+
+    def __enter__(self) -> 'Connection':
+        self._data_api.begin()
+        return self
+
+    def __exit__(self, exc_type: Any, exc_val: Any, exc_tb: Any) -> None:
+        if exc_type is None:
+            self.commit()
+        else:
+            if self._data_api.rollback_exception:
+                if issubclass(exc_type, self._data_api.rollback_exception):
+                    self.rollback()
+                else:
+                    self.commit()
+            else:
+                self.rollback()
+
+
+class Cursor:
+    def __init__(self, data_api: DataAPI) -> None:
+        self._data_api: DataAPI = data_api
+        self.arraysize = 1
+
+        self.closed = False
+
+        self.description: Optional[List] = None
+
+        self._rows: List[List] = []
+        self._rowcount: int = -1
+
+    @property
+    def rowcount(self) -> int:
+        return self._rowcount
+
+    def close(self) -> None:
+        self.closed = True
+
+    def execute(
+        self, operation: Any, parameters: Optional[Dict[str, Any]] = None
+    ) -> 'Cursor':
+        self.description = None
+        result = self._data_api.execute(operation, parameters)
+        self.description = get_description(  # type: ignore
+            getattr(result, '_column_metadata')
+        )
+        rows: List[List] = getattr(result, '_rows')
+        self._rows = rows
+        self._rowcount = len(rows)
+        return self
+
+    def executemany(
+        self, operation: Any, seq_of_parameters: Optional[List[Dict[str, Any]]] = None
+    ) -> 'Cursor':
+        self.description = None
+        results = self._data_api.batch_execute(operation, seq_of_parameters)
+        self._rows = [result.generated_fields for result in results]
+        self._rowcount = len(self._rows)
+        self.description = []
+        return self
+
+    def fetchone(self) -> Optional[List]:
+        try:
+            return self._rows.pop(0)
+        except IndexError:
+            return None
+
+    def fetchmany(self, size: Optional[int] = None) -> List[List]:
+        size = size or self.arraysize
+        result, self._rows = self._rows[:size], self._rows[size:]
+        return result
+
+    def fetchall(self) -> List[List]:
+        rows = self._rows
+        self._rows = []
+        return rows
+
+    def setinputsizes(self, sizes: Any) -> None:  # pragma: no cover
+        pass
+
+    def setoutputsizes(self, sizes: Any) -> None:  # pragma: no cover
+        pass
+
+    def __iter__(self) -> Iterator[List]:
+        return iter(self._rows)
+
+
+def connect(
+    resource_arn: str,
+    secret_arn: str,
+    database: Optional[str] = None,
+    transaction_id: Optional[str] = None,
+    client: Optional[boto3.session.Session.client] = None,
+    rollback_exception: Optional[Type[Exception]] = None,
+    **kwargs: Any
+) -> Connection:
+    return Connection(
+        resource_arn=resource_arn,
+        secret_arn=secret_arn,
+        database=database,
+        transaction_id=transaction_id,
+        client=client,
+        rollback_exception=rollback_exception,
+        **kwargs
+    )

--- a/pydataapi/dialect.py
+++ b/pydataapi/dialect.py
@@ -1,0 +1,191 @@
+from abc import ABC
+from typing import Any, Type
+
+from pydataapi.dbapi import Connection
+from sqlalchemy.dialects.mysql.base import (
+    MySQLCompiler,
+    MySQLDDLCompiler,
+    MySQLIdentifierPreparer,
+    MySQLTypeCompiler,
+)
+from sqlalchemy.dialects.postgresql.base import (
+    PGCompiler,
+    PGDDLCompiler,
+    PGIdentifierPreparer,
+    PGInspector,
+    PGTypeCompiler,
+)
+from sqlalchemy.engine.default import DefaultDialect
+
+
+class DataAPIDialect(DefaultDialect, ABC):
+    driver: str = 'dataapi'
+    name = "mysql"
+    supports_alter = True
+
+    supports_native_boolean = True
+
+    max_identifier_length = 255
+    max_index_name_length = 64
+
+    supports_native_enum = False
+
+    supports_sane_rowcount = True
+    supports_sane_multi_rowcount = False
+    supports_multivalues_insert = True
+
+    supports_comments = True
+    inline_comments = True
+    default_paramstyle = "named"
+
+    cte_follows_insert = True
+
+    statement_compiler = MySQLCompiler
+    ddl_compiler = MySQLDDLCompiler
+    type_compiler = MySQLTypeCompiler
+
+    preparer = MySQLIdentifierPreparer
+
+    _backslash_escapes = True
+    _server_ansiquotes = False
+
+    @property
+    def _supports_cast(self) -> bool:
+        return True
+
+    @classmethod
+    def dbapi(cls) -> Type[Connection]:
+        return Connection
+
+    def get_columns(
+        self, connection: Any, table_name: Any, schema: Any = None, **kw: Any
+    ) -> None:  # pragma: no cover
+        pass
+
+    def get_primary_keys(
+        self, connection: Any, table_name: Any, schema: Any = None, **kw: Any
+    ) -> None:  # pragma: no cover
+        pass
+
+    def get_foreign_keys(
+        self, connection: Any, table_name: Any, schema: Any = None, **kw: Any
+    ) -> None:  # pragma: no cover
+        pass
+
+    def get_table_names(
+        self, connection: Any, schema: Any = None, **kw: Any
+    ) -> None:  # pragma: no cover
+        pass
+
+    def get_temp_table_names(
+        self, connection: Any, schema: Any = None, **kw: Any
+    ) -> None:  # pragma: no cover
+        pass
+
+    def get_view_names(
+        self, connection: Any, schema: Any = None, **kw: Any
+    ) -> None:  # pragma: no cover
+        pass
+
+    def get_temp_view_names(
+        self, connection: Any, schema: Any = None, **kw: Any
+    ) -> None:  # pragma: no cover
+        pass
+
+    def get_view_definition(
+        self, connection: Any, view_name: Any, schema: Any = None, **kw: Any
+    ) -> None:  # pragma: no cover
+        pass
+
+    def get_indexes(
+        self, connection: Any, table_name: Any, schema: Any = None, **kw: Any
+    ) -> None:  # pragma: no cover
+        pass
+
+    def get_unique_constraints(
+        self, connection: Any, table_name: Any, schema: Any = None, **kw: Any
+    ) -> None:  # pragma: no cover
+        pass
+
+    def get_check_constraints(
+        self, connection: Any, table_name: Any, schema: Any = None, **kw: Any
+    ) -> None:  # pragma: no cover
+        pass
+
+    def get_table_comment(
+        self, connection: Any, table_name: Any, schema: Any = None, **kw: Any
+    ) -> None:  # pragma: no cover
+        pass
+
+    def normalize_name(self, name: Any) -> None:  # pragma: no cover
+        pass
+
+    def denormalize_name(self, name: Any) -> None:  # pragma: no cover
+        pass
+
+    def has_table(
+        self, connection: Any, table_name: Any, schema: Any = None
+    ) -> None:  # pragma: no cover
+        pass
+
+    def has_sequence(
+        self, connection: Any, sequence_name: Any, schema: Any = None
+    ) -> None:  # pragma: no cover
+        pass
+
+    def _get_server_version_info(self, connection: Any) -> None:  # pragma: no cover
+        pass
+
+    def _get_default_schema_name(self, connection: Any) -> None:  # pragma: no cover
+        pass
+
+    def do_begin_twophase(self, connection: Any, xid: Any) -> None:  # pragma: no cover
+        pass
+
+    def do_prepare_twophase(
+        self, connection: Any, xid: Any
+    ) -> None:  # pragma: no cover
+        pass
+
+    def do_rollback_twophase(
+        self, connection: Any, xid: Any, is_prepared: bool = True, recover: bool = False
+    ) -> None:  # pragma: no cover
+        pass
+
+    def do_commit_twophase(
+        self, connection: Any, xid: Any, is_prepared: bool = True, recover: bool = False
+    ) -> None:  # pragma: no cover
+        pass
+
+    def do_recover_twophase(self, connection: Any) -> None:  # pragma: no cover
+        pass
+
+    def set_isolation_level(
+        self, dbapi_conn: Any, level: Any
+    ) -> None:  # pragma: no cover
+        pass
+
+    def get_isolation_level(self, dbapi_conn: Any) -> None:  # pragma: no cover
+        pass
+
+
+class MySQLDataAPIDialect(DataAPIDialect):
+    name = "mysql"
+    statement_compiler = MySQLCompiler
+    ddl_compiler = MySQLDDLCompiler
+    type_compiler = MySQLTypeCompiler
+
+    preparer = MySQLIdentifierPreparer
+
+
+class PostgreSQLDataAPIDialect(DataAPIDialect):
+    name = "postgresql"
+    supports_alter = True
+    max_identifier_length = 63
+    supports_sane_rowcount = True
+    statement_compiler = PGCompiler
+    ddl_compiler = PGDDLCompiler
+    type_compiler = PGTypeCompiler
+    preparer = PGIdentifierPreparer
+    inspector = PGInspector
+    isolation_level = None

--- a/pydataapi/pydataapi.py
+++ b/pydataapi/pydataapi.py
@@ -8,6 +8,7 @@ from typing import (
     List,
     Optional,
     Sequence,
+    Tuple,
     Type,
     TypeVar,
     Union,
@@ -281,7 +282,7 @@ class DataAPI(AbstractContextManager):
         self._transaction_id: Optional[str] = transaction_id
         self._client: boto3.session.Session.client = client or boto3.client('rds-data')
         self._transaction_status: Optional[str] = None
-        self._rollback_exception: Optional[Type[Exception]] = rollback_exception
+        self.rollback_exception: Optional[Type[Exception]] = rollback_exception
 
     def __enter__(self) -> 'DataAPI':
         self.begin()
@@ -291,8 +292,8 @@ class DataAPI(AbstractContextManager):
         if exc_type is None:
             self.commit()
         else:
-            if self._rollback_exception:
-                if issubclass(exc_type, self._rollback_exception):
+            if self.rollback_exception:
+                if issubclass(exc_type, self.rollback_exception):
                     self.rollback()
                 else:
                     self.commit()

--- a/scripts/format.sh
+++ b/scripts/format.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -e
+
+black pydataapi tests --skip-string-normalization
+isort --recursive -w 88  --combine-as --thirdparty pydataapi pydataapi tests -m 3 -tc

--- a/setup.py
+++ b/setup.py
@@ -15,4 +15,11 @@ extras_require = {
 extras_require['all'] = [*extras_require.values()]
 use_scm_version = {'write_to': Path(config['metadata']['name'].replace('-', ''), 'version.py')}
 
-setup(extras_require=extras_require, use_scm_version=use_scm_version)
+entry_points = {
+    'sqlalchemy.dialects': [
+        'mysql.pydataapi = pydataapi.dialect:MySQLDataAPIDialect',
+        'postgresql.pydataapi = pydataapi.dialect:PostgreSQLDataAPIDialect',
+    ],
+}
+
+setup(extras_require=extras_require, use_scm_version=use_scm_version, entry_points=entry_points)

--- a/tests/pydataapi/test_dbaapi.py
+++ b/tests/pydataapi/test_dbaapi.py
@@ -1,0 +1,292 @@
+import pytest
+from pydataapi import connect
+
+
+@pytest.fixture
+def mocked_client(mocker):
+    return mocker.patch('boto3.client')
+
+
+def test_commit(mocked_client, mocker) -> None:
+    mocked_client.commit_transaction.return_value = {'transactionStatus': 'abc'}
+
+    data_api = connect(
+        resource_arn='dummy',
+        secret_arn='dummy',
+        database='test',
+        client=mocked_client,
+        transaction_id='abc',
+    )
+    data_api.commit()
+    assert mocked_client.commit_transaction.call_args == mocker.call(
+        resourceArn='dummy', transactionId='abc', secretArn='dummy'
+    )
+
+
+def test_commit_not_called(mocked_client, mocker) -> None:
+
+    data_api = connect(
+        resource_arn='dummy', secret_arn='dummy', database='test', client=mocked_client
+    )
+    data_api.commit()
+    mocked_client.commit_transaction.assert_not_called()
+
+
+def test_rollback(mocked_client, mocker) -> None:
+    mocked_client.rollback_transaction.return_value = {'transactionStatus': 'abc'}
+    data_api = connect(
+        resource_arn='dummy',
+        secret_arn='dummy',
+        database='test',
+        client=mocked_client,
+        transaction_id='abc',
+    )
+    data_api.rollback()
+    assert mocked_client.rollback_transaction.call_args == mocker.call(
+        resourceArn='dummy', transactionId='abc', secretArn='dummy'
+    )
+
+
+def test_rollback_not_called(mocked_client) -> None:
+    data_api = connect(
+        resource_arn='dummy', secret_arn='dummy', database='test', client=mocked_client
+    )
+    data_api.rollback()
+    mocked_client.rollback_transaction.assert_not_called()
+
+
+def test_execute_insert(mocked_client, mocker) -> None:
+    mocked_client.execute_statement.return_value = {
+        'generatedFields': [],
+        'numberOfRecordsUpdated': 1,
+    }
+    data_api = connect(
+        resource_arn='dummy', secret_arn='dummy', database='test', client=mocked_client
+    )
+    results = data_api.execute("insert into pets values(1, 'cat')")
+    assert list(results.fetchall()) == []
+    assert mocked_client.execute_statement.call_args == mocker.call(
+        continueAfterTimeout=True,
+        includeResultMetadata=True,
+        resourceArn='dummy',
+        secretArn='dummy',
+        sql="insert into pets values(1, 'cat')",
+        database='test',
+    )
+
+
+def test_execute_insert_parameters(mocked_client, mocker) -> None:
+    mocked_client.execute_statement.return_value = {
+        'generatedFields': [],
+        'numberOfRecordsUpdated': 1,
+    }
+    data_api = connect(
+        resource_arn='dummy', secret_arn='dummy', database='test', client=mocked_client
+    )
+    results = data_api.execute(
+        "insert into pets values(:id, :name)", {'id': 1, 'name': 'cat'}
+    )
+    assert list(results.fetchall()) == []
+    # assert results.number_of_records_updated == 1
+    assert mocked_client.execute_statement.call_args == mocker.call(
+        continueAfterTimeout=True,
+        includeResultMetadata=True,
+        parameters=[
+            {'name': 'id', 'value': {'longValue': 1}},
+            {'name': 'name', 'value': {'stringValue': 'cat'}},
+        ],
+        resourceArn='dummy',
+        secretArn='dummy',
+        sql="insert into pets values(:id, :name)",
+        database='test',
+    )
+
+
+def test_execute_select(mocked_client, mocker) -> None:
+    mocked_client.execute_statement.return_value = {
+        'numberOfRecordsUpdated': 0,
+        'records': [[{'longValue': 1}, {'stringValue': 'cat'}]],
+    }
+    data_api = connect(
+        resource_arn='dummy', secret_arn='dummy', database='test', client=mocked_client
+    )
+    result = data_api.cursor().execute("select * from pets")
+    assert result.rowcount == 1
+    assert result.fetchone() == [1, 'cat']
+    assert result.fetchone() is None
+    assert mocked_client.execute_statement.call_args == mocker.call(
+        continueAfterTimeout=True,
+        database='test',
+        includeResultMetadata=True,
+        resourceArn='dummy',
+        secretArn='dummy',
+        sql='select * from pets',
+    )
+
+    data_api.close()
+    assert data_api.closed is True
+
+
+def test_execute_select_fetch_many(mocked_client, mocker) -> None:
+    mocked_client.execute_statement.return_value = {
+        'numberOfRecordsUpdated': 0,
+        'records': [
+            [{'longValue': 1}, {'stringValue': 'cat'}],
+            [{'longValue': 2}, {'stringValue': 'dog'}],
+            [{'longValue': 3}, {'stringValue': 'snake'}],
+        ],
+    }
+    data_api = connect(
+        resource_arn='dummy', secret_arn='dummy', database='test', client=mocked_client
+    )
+    result = data_api.cursor().execute("select * from pets")
+    assert result.rowcount == 3
+    assert result.fetchmany(2) == [[1, 'cat'], [2, 'dog']]
+    assert result.fetchmany() == [[3, 'snake']]
+    assert mocked_client.execute_statement.call_args == mocker.call(
+        continueAfterTimeout=True,
+        database='test',
+        includeResultMetadata=True,
+        resourceArn='dummy',
+        secretArn='dummy',
+        sql='select * from pets',
+    )
+
+    data_api.close()
+    assert data_api.closed is True
+
+
+def test_execute_select_iter(mocked_client, mocker) -> None:
+    mocked_client.execute_statement.return_value = {
+        'numberOfRecordsUpdated': 0,
+        'records': [
+            [{'longValue': 1}, {'stringValue': 'cat'}],
+            [{'longValue': 2}, {'stringValue': 'dog'}],
+            [{'longValue': 3}, {'stringValue': 'snake'}],
+        ],
+    }
+    data_api = connect(
+        resource_arn='dummy', secret_arn='dummy', database='test', client=mocked_client
+    )
+    result = data_api.cursor().execute("select * from pets")
+    result_iter = iter(result)
+    assert next(result_iter) == [1, 'cat']
+    assert next(result_iter) == [2, 'dog']
+    assert next(result_iter) == [3, 'snake']
+    assert mocked_client.execute_statement.call_args == mocker.call(
+        continueAfterTimeout=True,
+        database='test',
+        includeResultMetadata=True,
+        resourceArn='dummy',
+        secretArn='dummy',
+        sql='select * from pets',
+    )
+
+    data_api.close()
+    assert data_api.closed is True
+
+
+def test_execute_insert_parameter_set(mocked_client, mocker) -> None:
+    mocked_client.batch_execute_statement.return_value = {
+        'updateResults': [
+            {'generatedFields': [{'longValue': 3}]},
+            {'generatedFields': [{'longValue': 4}]},
+        ]
+    }
+
+    data_api = connect(
+        resource_arn='dummy', secret_arn='dummy', database='test', client=mocked_client
+    )
+    results = data_api.cursor().executemany(
+        "insert into test.pets  values (:id , :name)",
+        [{'id': 3, 'name': 'bird'}, {'id': 4, 'name': 'lion'}],
+    )
+    rows = results.fetchall()
+    assert len(rows) == 2
+    assert rows == [[3], [4]]
+
+    assert mocked_client.batch_execute_statement.call_args == mocker.call(
+        resourceArn='dummy',
+        secretArn='dummy',
+        sql="insert into test.pets  values (:id , :name)",
+        parameterSets=[
+            [
+                {'name': 'id', 'value': {'longValue': 3}},
+                {'name': 'name', 'value': {'stringValue': 'bird'}},
+            ],
+            [
+                {'name': 'id', 'value': {'longValue': 4}},
+                {'name': 'name', 'value': {'stringValue': 'lion'}},
+            ],
+        ],
+        database='test',
+    )
+
+
+def test_with_statement(mocked_client) -> None:
+    mocked_client.begin_transaction.return_value = {'transactionId': 'abc'}
+    with connect(
+        resource_arn='dummy', secret_arn='dummy', database='test', client=mocked_client
+    ):
+        mocked_client.begin_transaction.assert_called_once_with(
+            database='test', resourceArn='dummy', secretArn='dummy'
+        )
+    mocked_client.commit_transaction.assert_called_once_with(
+        resourceArn='dummy', secretArn='dummy', transactionId='abc'
+    )
+
+
+def test_with_statement_exception(mocked_client) -> None:
+    mocked_client.begin_transaction.return_value = {'transactionId': 'abc'}
+    with pytest.raises(Exception):
+        with connect(
+            resource_arn='dummy',
+            secret_arn='dummy',
+            database='test',
+            client=mocked_client,
+        ):
+            mocked_client.begin_transaction.assert_called_once_with(
+                database='test', resourceArn='dummy', secretArn='dummy'
+            )
+            raise Exception('error')
+    mocked_client.rollback_transaction.assert_called_once_with(
+        resourceArn='dummy', secretArn='dummy', transactionId='abc'
+    )
+
+
+def test_with_statement_custom_exception(mocked_client, mocker) -> None:
+    class CustomError(Exception):
+        pass
+
+    mocked_client.begin_transaction.return_value = {'transactionId': 'abc'}
+    with pytest.raises(CustomError):
+        with connect(
+            resource_arn='dummy',
+            secret_arn='dummy',
+            database='test',
+            client=mocked_client,
+            rollback_exception=CustomError,
+        ):
+            mocked_client.begin_transaction.assert_called_once_with(
+                database='test', resourceArn='dummy', secretArn='dummy'
+            )
+            raise CustomError('error')
+    mocked_client.rollback_transaction.assert_called_once_with(
+        resourceArn='dummy', secretArn='dummy', transactionId='abc'
+    )
+
+    second_mocked_client = mocker.patch('boto3.client')
+    second_mocked_client.begin_transaction.return_value = {'transactionId': 'abc'}
+    with pytest.raises(Exception):
+        with connect(
+            resource_arn='dummy',
+            secret_arn='dummy',
+            database='test',
+            client=second_mocked_client,
+            rollback_exception=CustomError,
+        ):
+            second_mocked_client.begin_transaction.assert_called_once_with(
+                database='test', resourceArn='dummy', secretArn='dummy'
+            )
+            raise Exception('error')
+    second_mocked_client.rollback_transaction.assert_not_called()

--- a/tests/pydataapi/test_dialect.py
+++ b/tests/pydataapi/test_dialect.py
@@ -1,0 +1,125 @@
+import pytest
+from sqlalchemy.engine import ResultProxy
+
+
+@pytest.fixture
+def mocked_client(mocker):
+    return mocker.patch('boto3.client')
+
+
+def test_mysql(mocked_client) -> None:
+    from sqlalchemy.engine import create_engine
+
+    mocked_client.execute_statement.side_effect = [
+        {'records': [[{'stringValue': 'test plain returns'}]]},
+        {'records': [[{'stringValue': 'test unicode returns'}]]},
+        {
+            'numberOfRecordsUpdated': 0,
+            'records': [[{'longValue': 1}, {'stringValue': 'cat'}]],
+            "columnMetadata": [
+                {
+                    "arrayBaseColumnType": 0,
+                    "isAutoIncrement": False,
+                    "isCaseSensitive": False,
+                    "isCurrency": False,
+                    "isSigned": True,
+                    "label": "id",
+                    "name": "id",
+                    "nullable": 1,
+                    "precision": 11,
+                    "scale": 0,
+                    "schemaName": "",
+                    "tableName": "users",
+                    "type": 4,
+                    "typeName": "INT",
+                },
+                {
+                    "arrayBaseColumnType": 0,
+                    "isAutoIncrement": False,
+                    "isCaseSensitive": False,
+                    "isCurrency": False,
+                    "isSigned": False,
+                    "label": "name",
+                    "name": "name",
+                    "nullable": 1,
+                    "precision": 255,
+                    "scale": 0,
+                    "schemaName": "",
+                    "tableName": "users",
+                    "type": 12,
+                    "typeName": "VARCHAR",
+                },
+            ],
+        },
+    ]
+    engine = create_engine(
+        'mysql+pydataapi://',
+        connect_args={
+            'resource_arn': 'arn:aws:rds:us-east-1:123456789012:cluster:dummy',
+            'secret_arn': 'arn:aws:secretsmanager:us-east-1:123456789012:secret:dummy',
+            'database': 'test',
+            'client': mocked_client,
+        },
+    )
+
+    result: ResultProxy = engine.execute("select * from pets")
+    assert result.fetchall() == [(1, 'cat')]
+
+
+def test_postgresql(mocked_client) -> None:
+    from sqlalchemy.engine import create_engine
+
+    mocked_client.execute_statement.side_effect = [
+        {'records': [[{'stringValue': 'test plain returns'}]]},
+        {'records': [[{'stringValue': 'test unicode returns'}]]},
+        {
+            'numberOfRecordsUpdated': 0,
+            'records': [[{'longValue': 1}, {'stringValue': 'cat'}]],
+            "columnMetadata": [
+                {
+                    "arrayBaseColumnType": 0,
+                    "isAutoIncrement": False,
+                    "isCaseSensitive": False,
+                    "isCurrency": False,
+                    "isSigned": True,
+                    "label": "id",
+                    "name": "id",
+                    "nullable": 1,
+                    "precision": 11,
+                    "scale": 0,
+                    "schemaName": "",
+                    "tableName": "users",
+                    "type": 4,
+                    "typeName": "INT",
+                },
+                {
+                    "arrayBaseColumnType": 0,
+                    "isAutoIncrement": False,
+                    "isCaseSensitive": False,
+                    "isCurrency": False,
+                    "isSigned": False,
+                    "label": "name",
+                    "name": "name",
+                    "nullable": 1,
+                    "precision": 255,
+                    "scale": 0,
+                    "schemaName": "",
+                    "tableName": "users",
+                    "type": 12,
+                    "typeName": "VARCHAR",
+                },
+            ],
+        },
+    ]
+    engine = create_engine(
+        'postgresql+pydataapi://',
+        connect_args={
+            'resource_arn': 'arn:aws:rds:us-east-1:123456789012:cluster:dummy',
+            'secret_arn': 'arn:aws:secretsmanager:us-east-1:123456789012:secret:dummy',
+            'database': 'test',
+            'client': mocked_client,
+        },
+    )
+
+    result: ResultProxy = engine.execute("select * from pets")
+    assert result.fetchall() == [(1, 'cat')]


### PR DESCRIPTION
This PR supports db-api 2.0.
Also, I add a dialect for sqlalchemy.
We can use sqlalchemy and around tools.
But, the feature is experimental, We should test a lot of case.

eg:
```python
from sqlalchemy.engine import create_engine
engine = create_engine(
        'mysql+pydataapi://',
        connect_args={
            'resource_arn': 'arn:aws:rds:us-east-1:123456789012:cluster:dummy',
            'secret_arn': 'arn:aws:secretsmanager:us-east-1:123456789012:secret:dummy',
            'database': 'test'}
)
result = engine.execute("select * from pets")
print(result.fetchall())
# [(1, 'dog'),
# (2, 'cat'),
# (3, 'snake')]

```
## Related issues:
https://github.com/koxudaxi/py-data-api/issues/14
https://github.com/koxudaxi/py-data-api/issues/19
