### PR TITLE
Postgres migrations support 

### DIFF
--- a/pydataapi/dialect.py
+++ b/pydataapi/dialect.py
@@ -11,10 +11,10 @@ from sqlalchemy.dialects.mysql.base import (
 from sqlalchemy.dialects.postgresql.base import (
     PGCompiler,
     PGDDLCompiler,
+    PGDialect,
     PGIdentifierPreparer,
     PGInspector,
     PGTypeCompiler,
-    PGDialect,
 )
 from sqlalchemy.engine.default import DefaultDialect
 

--- a/pydataapi/dialect.py
+++ b/pydataapi/dialect.py
@@ -14,6 +14,7 @@ from sqlalchemy.dialects.postgresql.base import (
     PGIdentifierPreparer,
     PGInspector,
     PGTypeCompiler,
+    PGDialect,
 )
 from sqlalchemy.engine.default import DefaultDialect
 
@@ -178,7 +179,7 @@ class MySQLDataAPIDialect(DataAPIDialect):
     preparer = MySQLIdentifierPreparer
 
 
-class PostgreSQLDataAPIDialect(DataAPIDialect):
+class PostgreSQLDataAPIDialect(PGDialect, DataAPIDialect):
     name = "postgresql"
     supports_alter = True
     max_identifier_length = 63

--- a/tests/pydataapi/test_dialect.py
+++ b/tests/pydataapi/test_dialect.py
@@ -132,6 +132,27 @@ def test_postgresql(mocked_client) -> None:
                     'isCaseSensitive': True,
                     'isCurrency': False,
                     'isSigned': False,
+                    'label': 'transaction_isolation',
+                    'name': 'transaction_isolation',
+                    'nullable': 2,
+                    'precision': 2147483647,
+                    'scale': 0,
+                    'tableName': '',
+                    'type': 12,
+                    'typeName': 'text',
+                }
+            ],
+            'numberOfRecordsUpdated': 0,
+            'records': [[{'stringValue': 'read committed'}]],
+        },
+        {
+            'columnMetadata': [
+                {
+                    'arrayBaseColumnType': 0,
+                    'isAutoIncrement': False,
+                    'isCaseSensitive': True,
+                    'isCurrency': False,
+                    'isSigned': False,
                     'label': 'standard_conforming_strings',
                     'name': 'standard_conforming_strings',
                     'nullable': 2,

--- a/tests/pydataapi/test_dialect.py
+++ b/tests/pydataapi/test_dialect.py
@@ -74,8 +74,77 @@ def test_postgresql(mocked_client) -> None:
     mocked_client.begin_transaction.return_value = {'transactionId': 'abc'}
 
     mocked_client.execute_statement.side_effect = [
+        {
+            'records': [
+                [
+                    {
+                        'stringValue': 'PostgreSQL 10.7 on x86_64-pc-linux-musl, compiled by gcc (Alpine 8.3.0) 8.3.0, 64-bit'
+                    }
+                ]
+            ],
+            "columnMetadata": [
+                {
+                    "arrayBaseColumnType": 0,
+                    "isAutoIncrement": False,
+                    "isCaseSensitive": False,
+                    "isCurrency": False,
+                    "isSigned": False,
+                    "label": "name",
+                    "name": "name",
+                    "nullable": 1,
+                    "precision": 255,
+                    "scale": 0,
+                    "schemaName": "",
+                    "tableName": "users",
+                    "type": 12,
+                    "typeName": "VARCHAR",
+                }
+            ],
+        },
+        {
+            'columnMetadata': [
+                {
+                    'arrayBaseColumnType': 0,
+                    'isAutoIncrement': False,
+                    'isCaseSensitive': True,
+                    'isCurrency': False,
+                    'isSigned': False,
+                    'label': 'current_schema',
+                    'name': 'current_schema',
+                    'nullable': 2,
+                    'precision': 2147483647,
+                    'scale': 0,
+                    'tableName': '',
+                    'type': 12,
+                    'typeName': 'name',
+                }
+            ],
+            'numberOfRecordsUpdated': 0,
+            'records': [[{'stringValue': 'public'}]],
+        },
         {'records': [[{'stringValue': 'test plain returns'}]]},
         {'records': [[{'stringValue': 'test unicode returns'}]]},
+        {
+            'columnMetadata': [
+                {
+                    'arrayBaseColumnType': 0,
+                    'isAutoIncrement': False,
+                    'isCaseSensitive': True,
+                    'isCurrency': False,
+                    'isSigned': False,
+                    'label': 'standard_conforming_strings',
+                    'name': 'standard_conforming_strings',
+                    'nullable': 2,
+                    'precision': 2147483647,
+                    'scale': 0,
+                    'tableName': '',
+                    'type': 12,
+                    'typeName': 'text',
+                }
+            ],
+            'numberOfRecordsUpdated': 0,
+            'records': [[{'stringValue': 'on'}]],
+        },
         {
             'numberOfRecordsUpdated': 0,
             'records': [[{'longValue': 1}, {'stringValue': 'cat'}]],


### PR DESCRIPTION
@koxudaxi 

This commit serves to add support for postgres db migrations using Alembic. #19 

This will probably need to be updated further to support MySql.