### PR TITLE
Support arrary column

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,8 +11,12 @@ Also, the package includes DB API 2.0 Client and SQLAlchemy Dialects.
 
 ## Features
 - A user-friendly client which supports SQLAlchemy models
-- SQLAlchemy Dialects (experimental)
+- SQLAlchemy Dialects
 - DB API 2.0 compatible client [PEP 249](https://www.python.org/dev/peps/pep-0249/)
+
+## Support Database Engines
+- MySQL
+- PostgreSQL
 
 ## What's AWS Aurora Serverless's Data API?
 https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/data-api.html

--- a/pydataapi/pydataapi.py
+++ b/pydataapi/pydataapi.py
@@ -178,7 +178,7 @@ def _get_value_from_row(row: Dict[str, Any]) -> Any:
         array_value: Union[List[Dict[str, Dict]], Dict[str, List]] = value[array_key]
         if array_key == ARRAY_VALUES:
             return [
-                tuple(nested_value[ARRAY_VALUE].values())[0]
+                tuple(nested_value[ARRAY_VALUE].values())[0]  # type: ignore
                 for nested_value in array_value
             ]
         return array_value

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -2,5 +2,5 @@
 set -e
 
 export AWS_DEFAULT_REGION=us-west-2
-pytest --cov=pydataapi --ignore-glob=tests/integration/** tests
+pytest --cov=pydataapi --ignore-glob=tests/integration/**  --cov-report term-missing  tests
 pytest  --docker-compose-no-build --use-running-containers --docker-compose=tests/integration/docker-compose.yml tests/integration/


### PR DESCRIPTION
This PR supports the array column for PostgreSQL.

You can set/get values from PostgresSQL based Aurora instance.

## Related Issues and PRs
https://github.com/koxudaxi/py-data-api/issues/35
https://github.com/koxudaxi/local-data-api/pull/36

## AWS official documents 
https://docs.aws.amazon.com/rdsdataservice/latest/APIReference/API_Field.html#rdsdtataservice-Type-Field-arrayValue