### PR TITLE
Use the region name from the database ARN

### DIFF
--- a/pydataapi/pydataapi.py
+++ b/pydataapi/pydataapi.py
@@ -462,8 +462,13 @@ class DataAPI(AbstractContextManager):
         self.secret_arn: str = secret_arn
         self.database: Optional[str] = database
 
+        client_kwargs = {}
+        region_name = resource_arn.split(':')[3]
+        if region_name:
+            client_kwargs['region_name'] = region_name
+
         self._transaction_id: Optional[str] = transaction_id
-        self._client: boto3.session.Session.client = client or boto3.client('rds-data')
+        self._client: boto3.session.Session.client = client or boto3.client('rds-data', **client_kwargs)
         self._transaction_status: Optional[str] = None
         self.rollback_exception: Optional[Type[Exception]] = rollback_exception
 


### PR DESCRIPTION
Depending on how you logged into AWS, it's possible for the default region to be different from the one your database is in. py-data-api couldn't connect to the database in that case. But boto3 would still let you connect, provided you instantiated the client with an explicit region name. This PR makes py-data-api use an explicit region name when one is provided in the ARN.