### PR TITLE
Be less strict with the boto3 and sqlalchemy version requirements

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -26,8 +26,8 @@ setup_requires =
     pytest-runner
     setuptools-scm
 install_requires =
-    boto3 == 1.12.7
-    SQLAlchemy == 1.3.13
+    boto3 >=1.12.7,<1.14
+    SQLAlchemy >=1.3.13,<1.4
     pydantic == 1.4
     more-itertools == 8.0.2
 


### PR DESCRIPTION
I'm using pydataapi with boto3 version 1.13.23 and sqlalchemy 1.3.17 without issue. The requirement to use an old version is causing some trouble with continuous integration, though.

This PR loosens the requirements in setup.cfg to allow changes in micro versions within 1.12 and 1.13.