### PR TITLE
Allow recent more-itertools version

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -26,8 +26,8 @@ setup_requires =
     pytest-runner
     setuptools-scm
 install_requires =
-    boto3 == 1.12.7
-    SQLAlchemy == 1.3.13
+    boto3 >=1.12.7,<1.14
+    SQLAlchemy >=1.3.13,<1.4
     pydantic == 1.4
     more-itertools == 8.0.2
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -29,7 +29,7 @@ install_requires =
     boto3 >=1.12.7,<1.14
     SQLAlchemy >=1.3.13,<1.4
     pydantic == 1.4
-    more-itertools == 8.0.2
+    more-itertools >= 8.0.2,<8.5
 
 tests_require =
     pytest


### PR DESCRIPTION
I'm using py-data-api with Python 3.8, which `more-itertools` 8.0.2 doesn't support. But `py-data-api` seems to work fine with `more-itertools` 8.4.0. This PR loosens the required version of that package to allow anything in that range.