### PR TITLE
Make the boto3 requirement even less restrictive

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -26,8 +26,8 @@ setup_requires =
     pytest-runner
     setuptools-scm
 install_requires =
-    boto3 == 1.12.7
-    SQLAlchemy == 1.3.13
+    boto3 >=1.12.7,<1.14
+    SQLAlchemy >=1.3.13,<1.4
     pydantic == 1.4
     more-itertools == 8.0.2
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -29,7 +29,7 @@ install_requires =
     boto3 >=1.12.7,<1.14
     SQLAlchemy >=1.3.13,<1.4
     pydantic == 1.4
-    more-itertools == 8.0.2
+    more-itertools >= 8.0.2,<8.5
 
 tests_require =
     pytest

--- a/setup.cfg
+++ b/setup.cfg
@@ -26,7 +26,7 @@ setup_requires =
     pytest-runner
     setuptools-scm
 install_requires =
-    boto3 >=1.12.7,<1.14
+    boto3 >=1.12.7,<2
     SQLAlchemy >=1.3.13,<1.4
     pydantic == 1.4
     more-itertools >= 8.0.2,<8.5


### PR DESCRIPTION
Remember the last couple times I had deployment issues because of the required boto3 versions? Well, it happened again with the upgrade to boto3==1.14.

I've set the upper version limit to 2 this time so you won't have to do this again for a while. I feel like Amazon prefers to keep deprecated APIs around for some time.