### PR TITLE
Update regex for has_table to work with latest version of local-data-api

### DIFF
--- a/pydataapi/dialect/base.py
+++ b/pydataapi/dialect/base.py
@@ -109,7 +109,8 @@ class DataAPIDialectMixin:
             return super().has_table(connection, table_name, schema)  # type: ignore
         except ClientError as e:
             if re.match(
-                r"Table '.+' doesn't exist", e.response['Error']['Message']
+                r"(\(conn=\d+\) )?Table '.+' doesn't exist",
+                e.response['Error']['Message'],
             ):  # pragma: no cover
                 return False
             raise  # pragma: no cover

--- a/pydataapi/pydataapi.py
+++ b/pydataapi/pydataapi.py
@@ -245,7 +245,10 @@ class Result(
     def __len__(self) -> int:
         return len(self._rows)
 
-    def __init__(self, response: Dict[Any, Any],) -> None:
+    def __init__(
+        self,
+        response: Dict[Any, Any],
+    ) -> None:
         self._response = response
         self._rows = [
             [_get_value_from_row(column) for column in row]

--- a/tests/integration/docker-compose.yml
+++ b/tests/integration/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3.1'
 
 services:
   local-data-api-mysql:
-    image: koxudaxi/local-data-api:0.4.7
+    image: koxudaxi/local-data-api:0.5.1
     restart: always
     environment:
       MYSQL_HOST: mysql

--- a/tests/integration/test_mysql.py
+++ b/tests/integration/test_mysql.py
@@ -244,4 +244,8 @@ def test_dialect(create_table) -> None:
     session.commit()
 
     result = list(engine.execute('select * from pets'))
-    assert result[0] == (1, 'dog', '2020-01-02 03:04:05.678912',)
+    assert result[0] == (
+        1,
+        'dog',
+        '2020-01-02 03:04:05.678912',
+    )


### PR DESCRIPTION
Updating the regex for has_table to work with the latest version of the local-data-api. See issue described here:
https://github.com/koxudaxi/py-data-api/issues/73

Also some formatting changes from the running the formatting script.