### PR TITLE
add auto_transaction connection arg to control whether a transaction is auto-started when creating a cursor

### DIFF
--- a/pydataapi/dbapi.py
+++ b/pydataapi/dbapi.py
@@ -96,6 +96,7 @@ class ConnectArgs(BaseModel):
     client: Optional[Any] = None
     rollback_exception: Optional[Type[Exception]] = None
     rds_client: Optional[Any] = None
+    auto_transaction: Optional[bool] = True
 
 
 class Connection:
@@ -113,6 +114,7 @@ class Connection:
             client=connect_args.client,
             rollback_exception=connect_args.rollback_exception,
             rds_client=connect_args.rds_client,
+            auto_transaction=connect_args.auto_transaction,
         )
 
         self.closed = False
@@ -132,7 +134,7 @@ class Connection:
             self._data_api._transaction_id = None
 
     def cursor(self) -> 'Cursor':
-        if not self._data_api.transaction_id:
+        if not self._data_api.transaction_id and self._data_api.auto_transaction:
             self._data_api.begin()
         cursor = Cursor(self._data_api)
         self.cursors.append(cursor)

--- a/pydataapi/pydataapi.py
+++ b/pydataapi/pydataapi.py
@@ -365,6 +365,7 @@ class DataAPI:
         client: Optional[boto3.session.Session.client] = None,
         rollback_exception: Optional[Type[Exception]] = None,
         rds_client: Optional[boto3.session.Session.client] = None,
+        auto_transaction: Optional[bool] = None,
     ) -> None:
         if resource_name:
             if resource_arn:
@@ -389,6 +390,7 @@ class DataAPI:
         )
         self._transaction_status: Optional[str] = None
         self.rollback_exception: Optional[Type[Exception]] = rollback_exception
+        self._auto_transaction: Optional[bool] = auto_transaction
 
     def __enter__(self) -> "DataAPI":
         self.begin()
@@ -417,6 +419,10 @@ class DataAPI:
     @property
     def transaction_status(self) -> Optional[str]:
         return self._transaction_status
+
+    @property
+    def auto_transaction(self) -> Optional[bool]:
+        return self._auto_transaction
 
     def begin(
         self, database: Optional[str] = None, schema: Optional[str] = None


### PR DESCRIPTION
fixes #75 