### PR TITLE
Add failing date-time test

### DIFF
--- a/tests/integration/test_mysql.py
+++ b/tests/integration/test_mysql.py
@@ -249,3 +249,7 @@ def test_dialect(create_table) -> None:
         'dog',
         '2020-01-02 03:04:05.678912',
     )
+
+    # Check that the queried back dog is correct.
+    the_dog = session.query(Pets).filter_by(id=dog.id).one()
+    assert the_dog.seen_at == datetime(2020, 1, 2, 3, 4, 5, 678912)


### PR DESCRIPTION
Hi,

I'm hitting an issue where Datetime columns are not returned as datetime objects. I see support was added: https://github.com/koxudaxi/py-data-api/issues/40

But I'm still hitting the issue where I query a Datetime column and get back a string type. I'm using postgresql. But I've added assertion to the integration tests to illustrate the issue.

Thanks very much.